### PR TITLE
feat: make pixi install opt-in on welcome wizard

### DIFF
--- a/extensions/orion-launcher/package.json
+++ b/extensions/orion-launcher/package.json
@@ -2,7 +2,7 @@
   "name": "orion-launcher",
   "displayName": "Orion Launcher",
   "description": "Welcome wizard and setup for Orion Studio",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "engines": {
     "vscode": "^1.95.0"
   },

--- a/extensions/orion-launcher/src/OrionWizardPanel.ts
+++ b/extensions/orion-launcher/src/OrionWizardPanel.ts
@@ -104,8 +104,8 @@ export class OrionWizardPanel {
           case "expressSetup":
             this.dispose();
             const { runExpressSetup } = await import("./extension");
-            // Pass the repository ID from the UI button clicked
-            await runExpressSetup(message.repoId);
+            // Pass the repository ID and installPixi flag from the UI
+            await runExpressSetup(message.repoId, message.installPixi ?? false);
             return;
           case "saveConfig":
             this._saveConfig(message.config);
@@ -542,6 +542,15 @@ export class OrionWizardPanel {
                                 <p class="action-description">
                                     Opens a fresh notebook environment ready to use
                                 </p>
+                                <div class="pixi-option" style="margin-top: 16px;">
+                                    <label style="display: flex; align-items: center; justify-content: center; gap: 8px; cursor: pointer; font-size: 0.9em;">
+                                        <input type="checkbox" id="installPixiExpress">
+                                        Install/update Python environment (pixi install)
+                                    </label>
+                                    <p style="margin-top: 4px; opacity: 0.6; font-size: 0.8em;">
+                                        Check this if setting up for the first time or updating dependencies
+                                    </p>
+                                </div>
                             </div>
 
                             <div class="secondary-action">
@@ -647,6 +656,15 @@ export class OrionWizardPanel {
                             </label>
                         </div>
 
+                        <div class="input-group">
+                            <label>
+                                <input type="checkbox" id="installPixiAdvanced"> Install/update Python environment (pixi install)
+                            </label>
+                            <p style="margin-top: 4px; opacity: 0.6; font-size: 0.8em;">
+                                Check this if setting up for the first time or updating dependencies
+                            </p>
+                        </div>
+
                         <button class="btn" onclick="finishSetup()">Start Orion Studio</button>
                         <button class="btn btn-secondary" onclick="prevStep(2)">Back</button>
                     </div>
@@ -678,8 +696,10 @@ export class OrionWizardPanel {
                         document.getElementById('loading-overlay').classList.add('active');
                         // Disable all express buttons
                         document.querySelectorAll('.btn-express').forEach(btn => btn.disabled = true);
-                        // Send message to extension with the repository ID
-                        vscode.postMessage({ command: 'expressSetup', repoId: repoId });
+                        // Get the pixi install checkbox value
+                        const installPixi = document.getElementById('installPixiExpress').checked;
+                        // Send message to extension with the repository ID and installPixi flag
+                        vscode.postMessage({ command: 'expressSetup', repoId: repoId, installPixi: installPixi });
                     }
 
                     function nextStep(step) {
@@ -776,6 +796,7 @@ export class OrionWizardPanel {
                             targetDir: targetDir,
                             branchName: document.getElementById('branchName').value,
                             enableCopilot: document.getElementById('enableCopilot').checked,
+                            installPixi: document.getElementById('installPixiAdvanced').checked,
                             setupDate: new Date().toISOString()
                         };
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -3,7 +3,7 @@ authors = ["Chen Zhang <chenzhang8722@gmail.com>"]
 channels = ["conda-forge"]
 name = "orion"
 platforms = ["osx-arm64", "linux-64"]
-version = "1.2.0"
+version = "1.3.0"
 
 [tasks]
 build = "python scripts/build_orion.py"


### PR DESCRIPTION
## Summary

- Add checkbox to Express Setup and Advanced Setup flows for opt-in pixi install
- Default is unchecked - skips pixi install for faster startup
- Users can check the box when they need to set up or update Python environment
- Improves UX when network is slow or unavailable

Closes #17

## Changes

| File | Change |
|------|--------|
| `extension.ts` | Add `installPixi` to config interface; modify `runExpressSetup()` and `runSetup()` to skip pixi when flag is false |
| `OrionWizardPanel.ts` | Add checkbox UI to Express and Advanced setup; pass `installPixi` flag in messages |
| `package.json` | Bump version to 1.3.0 |
| `pixi.toml` | Bump version to 1.3.0 |

## Test plan

- [ ] Open Orion with checkbox unchecked → should skip pixi install, open workspace quickly
- [ ] Open Orion with checkbox checked → should run pixi install as before
- [ ] Test both Express Setup and Advanced Setup flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)