### PR TITLE
fix: sync package-lock.json version and improve pixi checkbox UX

### DIFF
--- a/extensions/orion-launcher/package-lock.json
+++ b/extensions/orion-launcher/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "orion-launcher",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "orion-launcher",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "dependencies": {
         "simple-git": "^3.22.0"
       },

--- a/extensions/orion-launcher/src/OrionWizardPanel.ts
+++ b/extensions/orion-launcher/src/OrionWizardPanel.ts
@@ -543,12 +543,13 @@ export class OrionWizardPanel {
                                     Opens a fresh notebook environment ready to use
                                 </p>
                                 <div class="pixi-option" style="margin-top: 16px;">
-                                    <label style="display: flex; align-items: center; justify-content: center; gap: 8px; cursor: pointer; font-size: 0.9em;">
+                                    <label style="display: flex; align-items: center; justify-content: center; gap: 8px; cursor: pointer; font-size: 0.9em;"
+                                           title="Runs 'pixi install' to set up or update the Python environment. May be slow or hang on poor network connections.">
                                         <input type="checkbox" id="installPixiExpress">
                                         Install/update Python environment (pixi install)
                                     </label>
                                     <p style="margin-top: 4px; opacity: 0.6; font-size: 0.8em;">
-                                        Check this if setting up for the first time or updating dependencies
+                                        Check this if setting up for the first time or updating dependencies. May be slow on poor networks.
                                     </p>
                                 </div>
                             </div>
@@ -657,11 +658,11 @@ export class OrionWizardPanel {
                         </div>
 
                         <div class="input-group">
-                            <label>
+                            <label title="Runs 'pixi install' to set up or update the Python environment. May be slow or hang on poor network connections.">
                                 <input type="checkbox" id="installPixiAdvanced"> Install/update Python environment (pixi install)
                             </label>
                             <p style="margin-top: 4px; opacity: 0.6; font-size: 0.8em;">
-                                Check this if setting up for the first time or updating dependencies
+                                Check this if setting up for the first time or updating dependencies. May be slow on poor networks.
                             </p>
                         </div>
 


### PR DESCRIPTION
## Summary

- Sync `package-lock.json` version from 1.2.0 to 1.3.0 to match `package.json`
- Add tooltip (title attribute) to pixi install checkboxes explaining the option
- Update helper text to warn about potential slowness on poor networks

## Changes

| File | Change |
|------|--------|
| `package-lock.json` | Update version 1.2.0 → 1.3.0 (top-level and packages[""]) |
| `OrionWizardPanel.ts` | Add `title` tooltip and update helper text for both Express and Advanced checkboxes |

## Details

**Tooltip text** (shown on hover):
> Runs 'pixi install' to set up or update the Python environment. May be slow or hang on poor network connections.

**Updated helper text**:
> Check this if setting up for the first time or updating dependencies. May be slow on poor networks.

## Test plan

- [ ] Hover over pixi checkbox in Express Setup → tooltip appears
- [ ] Hover over pixi checkbox in Advanced Setup → tooltip appears
- [ ] Helper text shows network warning in both flows
- [ ] Run `npm install` → package-lock.json shows 1.3.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)