### PR TITLE
release: v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to Orion Studio will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] - 2026-04-07
+
+### Fixed
+
+- **Explicit Jupyter kernel registration** — After pixi environment setup,
+  the kernel is now registered explicitly via `ipykernel install --user`,
+  preventing VS Code from falsely reporting ipykernel as missing due to
+  fragile auto-discovery with pixi-managed environments.
+- Each notebook repo (Reduction, Reconstruction) gets its own named kernel
+  (`orion-orion_notebooks`, `orion-orion_ct_recon`) to avoid cross-environment
+  conflicts.
+
+### Changed
+
+- **Updated VS Code base to 1.114.0** (latest stable release)
+- Updated fallback VS Code version from 1.113.0 to 1.114.0
+- Raised minimum VS Code engine requirement to ^1.114.0
+- Kernel registration uses async `execFile` (no shell) for safety and to
+  avoid blocking the extension host event loop
+
 ## [1.5.0] - 2026-03-30
 
 ### Changed
@@ -145,6 +165,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Build: Python 3.11 with Pixi environment management
 - Icon Generation: cairosvg for SVG to PNG/ICNS conversion
 
+[1.5.1]: https://github.com/ornlneutronimaging/orion/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/ornlneutronimaging/orion/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/ornlneutronimaging/orion/compare/v1.3.0...v1.4.0
 [1.2.0]: https://github.com/ornlneutronimaging/orion/compare/v1.1.1...v1.2.0

--- a/extensions/orion-launcher/package.json
+++ b/extensions/orion-launcher/package.json
@@ -2,9 +2,9 @@
   "name": "orion-launcher",
   "displayName": "Orion Launcher",
   "description": "Welcome wizard and setup for Orion Studio",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "engines": {
-    "vscode": "^1.113.0"
+    "vscode": "^1.114.0"
   },
   "categories": [
     "Other"

--- a/pixi.toml
+++ b/pixi.toml
@@ -3,7 +3,7 @@ authors = ["Chen Zhang <chenzhang8722@gmail.com>"]
 channels = ["conda-forge"]
 name = "orion"
 platforms = ["osx-arm64", "linux-64"]
-version = "1.5.0"
+version = "1.5.1"
 
 [tasks]
 build = "python scripts/build_orion.py"

--- a/scripts/build_orion.py
+++ b/scripts/build_orion.py
@@ -15,7 +15,7 @@ import cairosvg
 # Configuration
 APP_NAME = "OrionStudio"
 RESOURCES_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "resources")
-FALLBACK_VSCODE_VERSION = "1.113.0"
+FALLBACK_VSCODE_VERSION = "1.114.0"
 CONFIG_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "config")
 BUILD_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "build")
 DIST_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "dist")


### PR DESCRIPTION
## Summary
- Bump version to 1.5.1
- Update VS Code base from 1.113.0 to 1.114.0
- Includes fix from #38: explicit Jupyter kernel registration to prevent false ipykernel-missing errors, with per-repo kernel names

## Changes
- `pixi.toml` / `package.json`: version 1.5.0 → 1.5.1
- `package.json`: engine ^1.113.0 → ^1.114.0
- `build_orion.py`: fallback VS Code 1.113.0 → 1.114.0
- `CHANGELOG.md`: added 1.5.1 entry

## Test plan
- [ ] CI builds pass (ubuntu + macOS)
- [ ] Merge and tag v1.5.1
- [ ] Build on server, deploy, verify kernel registration with both notebook repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)