### PR TITLE
release: v1.6.0 — VS Code 1.116.0, Copilot now built-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to Orion Studio will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - 2026-04-16
+
+### Changed
+
+- **Updated VS Code base to 1.116.0** (April 2026 release)
+  - GitHub Copilot (inline suggestions) and Copilot Chat are now built-in
+    extensions shipped with VS Code — no longer need to be bundled separately
+- Updated fallback VS Code version from 1.114.0 to 1.116.0
+- Raised minimum VS Code engine requirement to ^1.116.0
+
+### Removed
+
+- **`GitHub.copilot` and `GitHub.copilot-chat` from bundled extensions** — Both
+  are now built-in to VS Code 1.116+. Bundling them separately is no longer
+  needed and could cause conflicts with the built-in versions.
+- Removed `github.copilot` and `github.copilot-chat` from
+  `remote.SSH.defaultExtensions` (built-in extensions auto-install on remotes)
+
+### Added
+
+- **Known limitation documented**: Orion Studio cannot run simultaneously on
+  multiple analysis machines that share the same NFS-mounted home directory,
+  due to Chromium's `SingletonLock` mechanism
+
 ## [1.5.1] - 2026-04-07
 
 ### Fixed
@@ -165,6 +189,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Build: Python 3.11 with Pixi environment management
 - Icon Generation: cairosvg for SVG to PNG/ICNS conversion
 
+[1.6.0]: https://github.com/ornlneutronimaging/orion/compare/v1.5.1...v1.6.0
 [1.5.1]: https://github.com/ornlneutronimaging/orion/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/ornlneutronimaging/orion/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/ornlneutronimaging/orion/compare/v1.3.0...v1.4.0

--- a/config/extensions.txt
+++ b/config/extensions.txt
@@ -3,7 +3,5 @@ ms-toolsai.jupyter
 ms-python.python
 ms-python.vscode-pylance
 ms-python.debugpy
-GitHub.copilot
-GitHub.copilot-chat
 tamasfe.even-better-toml
 h5web.vscode-h5web

--- a/config/settings.json
+++ b/config/settings.json
@@ -23,8 +23,6 @@
     "ms-python.python",
     "ms-python.vscode-pylance",
     "ms-python.debugpy",
-    "github.copilot",
-    "github.copilot-chat",
     "tamasfe.even-better-toml"
   ]
 }

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -356,6 +356,20 @@ Try prompts like:
 
 ## Troubleshooting
 
+### Cannot Run on Two Analysis Machines Simultaneously
+
+**Cause**: Orion Studio (via Electron/Chromium) creates a `SingletonLock` file in `~/.orion-studio/` when it starts. This lock contains the hostname and process ID of the running instance. When you try to launch Orion on a second analysis machine that shares the same NFS-mounted home directory, it detects that the lock was created by a different host and refuses to start with a "profile in use" error.
+
+This is an intentional Chromium safety mechanism to prevent data corruption from concurrent writes to the same profile directory.
+
+**Workaround**: Close Orion Studio on the first machine before launching it on the second. If the first machine crashed or became unreachable and left a stale lock, you can manually remove it:
+
+```bash
+rm -f ~/.orion-studio/SingletonLock ~/.orion-studio/SingletonSocket ~/.orion-studio/SingletonCookie
+```
+
+> **Warning**: Do not delete these files while Orion is still running on another machine. Running two instances against the same profile directory simultaneously can corrupt settings and extension databases.
+
 ### Connection Issues
 
 #### "Connection refused" when connecting to remote
@@ -512,4 +526,4 @@ Open an issue at: https://github.com/ornlneutronimaging/orion/issues
 
 ---
 
-*Last updated: December 2025*
+*Last updated: April 2026*

--- a/extensions/orion-launcher/package-lock.json
+++ b/extensions/orion-launcher/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "orion-launcher",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "orion-launcher",
-      "version": "1.5.1",
+      "version": "1.6.0",
       "dependencies": {
         "jsonc-parser": "^3.3.1",
         "simple-git": "^3.36.0"
@@ -17,7 +17,7 @@
         "typescript": "^6.0.3"
       },
       "engines": {
-        "vscode": "^1.114.0"
+        "vscode": "^1.116.0"
       }
     },
     "node_modules/@kwsites/file-exists": {

--- a/extensions/orion-launcher/package.json
+++ b/extensions/orion-launcher/package.json
@@ -2,9 +2,9 @@
   "name": "orion-launcher",
   "displayName": "Orion Launcher",
   "description": "Welcome wizard and setup for Orion Studio",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "engines": {
-    "vscode": "^1.114.0"
+    "vscode": "^1.116.0"
   },
   "categories": [
     "Other"

--- a/pixi.toml
+++ b/pixi.toml
@@ -3,7 +3,7 @@ authors = ["Chen Zhang <chenzhang8722@gmail.com>"]
 channels = ["conda-forge"]
 name = "orion"
 platforms = ["osx-arm64", "linux-64"]
-version = "1.5.1"
+version = "1.6.0"
 
 [tasks]
 build = "python scripts/build_orion.py"

--- a/scripts/build_orion.py
+++ b/scripts/build_orion.py
@@ -15,7 +15,7 @@ import cairosvg
 # Configuration
 APP_NAME = "OrionStudio"
 RESOURCES_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "resources")
-FALLBACK_VSCODE_VERSION = "1.114.0"
+FALLBACK_VSCODE_VERSION = "1.116.0"
 CONFIG_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "config")
 BUILD_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "build")
 DIST_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "dist")


### PR DESCRIPTION
## Summary

- **Updated VS Code base to 1.116.0** (April 2026 release)
- **Removed `GitHub.copilot` and `GitHub.copilot-chat` from bundled extensions** — both are now built-in to VS Code 1.116+. The built-in `copilot` extension provides chat, inline suggestions, and agents out of the box.
- **Documented NFS `SingletonLock` limitation** in the User Guide troubleshooting section (cannot run Orion simultaneously on two analysis machines sharing the same NFS home directory).
- Raised minimum VS Code engine requirement to `^1.116.0`.

## Why

VS Code 1.116 ships Copilot as a built-in extension. Continuing to bundle it separately would install a redundant (and potentially conflicting) marketplace copy. Removing it from `extensions.txt` and `remote.SSH.defaultExtensions` lets the built-in provide Copilot cleanly.

## Test plan

- [x] Built locally on macOS (`pixi run build`) — exit 0
- [x] Manual launch test passed (confirmed by maintainer)
- [ ] CI builds pass on macOS and Ubuntu
- [ ] Verify Copilot Chat and inline suggestions work without any bundled Copilot extension
- [ ] Verify Remote SSH still has Copilot available (built-in should auto-install on remote host)

See CHANGELOG.md for the full release notes entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)