### PR TITLE
ci: drop v0.39.2 pixi-version pin in workflows

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -26,8 +26,6 @@ jobs:
 
       - name: Install Pixi
         uses: prefix-dev/setup-pixi@v0.9.5
-        with:
-          pixi-version: v0.39.2
 
       - name: Install Linux Dependencies
         if: runner.os == 'Linux'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,6 @@ jobs:
 
       - name: Install Pixi
         uses: prefix-dev/setup-pixi@v0.9.5
-        with:
-          pixi-version: v0.39.2
 
       - name: Install Linux Dependencies
         if: runner.os == 'Linux'


### PR DESCRIPTION
## Summary
- Removes the `pixi-version: v0.39.2` pin from `ci-build.yml` and `release.yml` so workflows use the default pixi installed by `prefix-dev/setup-pixi`. Since the `with:` block contained only the pin, the empty `with:` is removed too.

## Why
Aligns this repo with the rest of the workspace — same pattern as the recent timepix_geometry_correction (#70) and RootPlantProcessing (#75) fixes. v0.39.2 is roughly a year out of date.

## Test plan
- [ ] ci-build workflow passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)