### PR TITLE
security: pin third-party GitHub Actions to commit SHAs + least-privilege permissions

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -7,6 +7,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -25,7 +28,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Pixi
-        uses: prefix-dev/setup-pixi@v0.9.6
+        uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
 
       - name: Install Linux Dependencies
         if: runner.os == 'Linux'

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 # Cancel previous runs when new commit pushed
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Pixi
-        uses: prefix-dev/setup-pixi@v0.9.6
+        uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
 
       - name: Install Linux Dependencies
         if: runner.os == 'Linux'
@@ -58,7 +58,7 @@ jobs:
         run: find artifacts -type f
 
       - name: Create Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         with:
           files: |
             artifacts/OrionStudio-macOS.dmg/OrionStudio-macOS.dmg


### PR DESCRIPTION
## What

Supply-chain hardening of this repo's GitHub Actions workflows, from the 2026-06-22 workspace GitHub Actions security audit.

- **SHA-pin third-party actions** to full 40-char commit SHAs, retaining a trailing `# version` comment for readability.
- **Least-privilege permissions:** add a top-level `permissions: contents: read` block to pure-CI workflows that have no existing permissions block and perform no write/publish operations.

First-party actions (`actions/*`, `github/*`) are intentionally left tag-pinned per group convention.

## Why

Tag refs (e.g. `@v3`) are mutable — a compromised or retagged upstream action could inject malicious code into CI. Pinning to immutable commit SHAs closes that supply-chain vector. The conservative `contents: read` default reduces the blast radius of any token leak in pure-CI jobs.

## Pins applied

| Action | Pinned SHA |
| --- | --- |
| `prefix-dev/setup-pixi@v0.9.6` (ci-build.yml, release.yml) | `5185adfbffb4bd703da3010310260805d89ebb11` |
| `softprops/action-gh-release@v3` (release.yml) | `718ea10b132b3b2eba29c1007bb80653f286566b` |

## Permissions added

- `ci-build.yml` — `permissions: contents: read`
- `pr-validation.yml` — `permissions: contents: read`

`release.yml` was intentionally left untouched for permissions: it contains a job-level `contents: write` and uses `softprops/action-gh-release` (it needs write access to publish releases), so per the conservative audit rules no top-level permissions block was added there.

## Notes

- No `dtolnay/rust-toolchain` or `taiki-e/install-action` uses exist in this repo, so those special-case handling steps did not apply.
- No behavior change intended; CI on this PR validates.

🤖 Assisted with Claude Code
